### PR TITLE
Feat: Creates ponder indexer

### DIFF
--- a/apps/indexer/abis/BleuNFT.ts
+++ b/apps/indexer/abis/BleuNFT.ts
@@ -1,0 +1,49 @@
+import { mergeAbis } from "ponder";
+import { erc721Abi } from "viem";
+
+export const BleuNFTAbi = mergeAbis([
+  erc721Abi,
+  [
+    {
+      inputs: [],
+      stateMutability: "nonpayable",
+      type: "constructor",
+    },
+    {
+      inputs: [
+        {
+          internalType: "address",
+          name: "to",
+          type: "address",
+        },
+        {
+          internalType: "uint256",
+          name: "tokenId",
+          type: "uint256",
+        },
+      ],
+      name: "mint",
+      outputs: [],
+      stateMutability: "nonpayable",
+      type: "function",
+    },
+    {
+      inputs: [
+        {
+          indexed: true,
+          internalType: "address",
+          name: "to",
+          type: "address",
+        },
+        {
+          indexed: true,
+          internalType: "uint256",
+          name: "tokenId",
+          type: "uint256",
+        },
+      ],
+      name: "Mint",
+      type: "event",
+    },
+  ],
+]);

--- a/apps/indexer/abis/BleuStakingContract.ts
+++ b/apps/indexer/abis/BleuStakingContract.ts
@@ -1,0 +1,124 @@
+export const BleuStakingContractAbi = [
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "_nftContract",
+        type: "address",
+      },
+    ],
+    stateMutability: "nonpayable",
+    type: "constructor",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_tokenId",
+        type: "uint256",
+      },
+    ],
+    name: "stake",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "uint256",
+        name: "_tokenId",
+        type: "uint256",
+      },
+    ],
+    name: "unstake",
+    outputs: [],
+    stateMutability: "nonpayable",
+    type: "function",
+  },
+  {
+    inputs: [],
+    name: "nftContract",
+    outputs: [
+      {
+        internalType: "contract IERC721",
+        name: "",
+        type: "address",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        internalType: "address",
+        name: "user",
+        type: "address",
+      },
+      {
+        internalType: "uint256",
+        name: "_tokenId",
+        type: "uint256",
+      },
+    ],
+    name: "stakedNFTs",
+    outputs: [
+      {
+        internalType: "uint256",
+        name: "",
+        type: "uint256",
+      },
+    ],
+    stateMutability: "view",
+    type: "function",
+  },
+  {
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "user",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "timestamp",
+        type: "uint256",
+      },
+    ],
+    name: "Staked",
+    type: "event",
+  },
+  {
+    inputs: [
+      {
+        indexed: true,
+        internalType: "address",
+        name: "user",
+        type: "address",
+      },
+      {
+        indexed: true,
+        internalType: "uint256",
+        name: "tokenId",
+        type: "uint256",
+      },
+      {
+        indexed: false,
+        internalType: "uint256",
+        name: "timestamp",
+        type: "uint256",
+      },
+    ],
+    name: "Unstaked",
+    type: "event",
+  },
+] as const;

--- a/apps/indexer/abis/ExampleContractAbi.ts
+++ b/apps/indexer/abis/ExampleContractAbi.ts
@@ -1,1 +1,0 @@
-export const ExampleContractAbi = [] as const;

--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -12,11 +12,12 @@
   "dependencies": {
     "hono": "^4.5.0",
     "ponder": "^0.9.5",
+    "uuid": "^11.1.0",
     "viem": "^2.21.3"
   },
   "devDependencies": {
-    "@types/node": "^22.13.1",
     "@biomejs/biome": "1.9.4",
+    "@types/node": "^22.13.1",
     "typescript": "^5.7.3"
   }
 }

--- a/apps/indexer/ponder-env.d.ts
+++ b/apps/indexer/ponder-env.d.ts
@@ -1,12 +1,12 @@
 /// <reference types="ponder/virtual" />
 
-declare module 'ponder:internal' {
-  const config: typeof import('./ponder.config.ts');
-  const schema: typeof import('./ponder.schema.ts');
+declare module "ponder:internal" {
+  const config: typeof import("./ponder.config.ts");
+  const schema: typeof import("./ponder.schema.ts");
 }
 
-declare module 'ponder:schema' {
-  export * from './ponder.schema.ts';
+declare module "ponder:schema" {
+  export * from "./ponder.schema.ts";
 }
 
 // This file enables type checking and editor autocomplete for this Ponder project.

--- a/apps/indexer/ponder.config.ts
+++ b/apps/indexer/ponder.config.ts
@@ -1,25 +1,33 @@
-import { createConfig } from 'ponder';
-import { http } from 'viem';
+import { createConfig } from "ponder";
+import { getAddress, http } from "viem";
+import BleuDeploy from "../contracts/broadcast/BleuNFT.s.sol/31337/run-latest.json";
+import { BleuNFTAbi } from "./abis/BleuNFT";
+import { BleuStakingContractAbi } from "./abis/BleuStakingContract";
+import { getContractAddress } from "./utils/getContractAddress";
 
-import { ExampleContractAbi } from './abis/ExampleContractAbi';
+const BleuNFTAddress = getAddress(BleuDeploy.transactions[0]!.contractAddress);
+const BleuStakingContractAddress = getAddress(
+  BleuDeploy.transactions[2]!.contractAddress
+);
 
 export default createConfig({
   networks: {
-    anvil_localhost_testnet: {
+    anvil: {
       chainId: 31337,
-      // This is Anvil's default RPC URL. Make sure you're running it.
-      transport: http('http://localhost:8545'),
+      transport: http("http://localhost:8545"),
+      disableCache: true,
     },
   },
   contracts: {
-    ExampleContract: {
-      network: 'anvil_localhost_testnet',
-      // TODO: Replace with the actual abi of the contract
-      // Note: You'll probably want to use a mergeAbis function to merge the abi with the erc721 abi
-      abi: ExampleContractAbi,
-      // TODO: Replace with the actual address of the contract
-      address: '0x0000000000000000000000000000000000000000',
-      startBlock: 1,
+    BleuNFT: {
+      network: "anvil",
+      abi: BleuNFTAbi,
+      address: getContractAddress("BleuNFT"),
+    },
+    BleuStakingContract: {
+      network: "anvil",
+      abi: BleuStakingContractAbi,
+      address: getContractAddress("BleuStakingContract"),
     },
   },
 });

--- a/apps/indexer/ponder.schema.ts
+++ b/apps/indexer/ponder.schema.ts
@@ -1,6 +1,20 @@
-import { onchainTable } from 'ponder';
+import { onchainEnum, onchainTable } from "ponder";
+import { v4 as uuidv4 } from "uuid";
 
-export const example = onchainTable('example', (t) => ({
-  id: t.text().primaryKey(),
-  name: t.text(),
+export const bleuNFT = onchainTable("bleu_nft", (t) => ({
+  id: t.bigint().primaryKey(),
+  owner: t.text(),
+}));
+
+export const stakingType = onchainEnum("type", ["STAKED", "UNSTAKED"]);
+
+export const bleuNFTStaking = onchainTable("bleu_nft_staked", (t) => ({
+  id: t
+    .text()
+    .primaryKey()
+    .$default(() => uuidv4()),
+  user: t.text().notNull(),
+  tokenId: t.bigint().notNull(),
+  type: stakingType("type").notNull(),
+  timestamp: t.bigint().notNull(),
 }));

--- a/apps/indexer/src/index.ts
+++ b/apps/indexer/src/index.ts
@@ -1,5 +1,37 @@
-import { ponder } from 'ponder:registry';
+import { ponder } from "ponder:registry";
+import { bleuNFT, bleuNFTStaking } from "ponder:schema";
 
-// ponder.on("YourContract:YourEvent", (event) => {
-//   console.log(event);
-// });
+ponder.on("BleuNFT:Mint", async ({ event, context }) => {
+  const { client, contracts } = context;
+  const { BleuNFT } = contracts;
+
+  const owner = await client.readContract({
+    abi: BleuNFT.abi,
+    address: BleuNFT.address,
+    functionName: "ownerOf",
+    args: [event.args.tokenId],
+  });
+
+  await context.db.insert(bleuNFT).values({
+    id: event.args.tokenId,
+    owner,
+  });
+});
+
+ponder.on("BleuStakingContract:Staked", async ({ event, context }) => {
+  await context.db.insert(bleuNFTStaking).values({
+    user: event.args.user,
+    tokenId: event.args.tokenId,
+    type: "STAKED",
+    timestamp: event.args.timestamp,
+  });
+});
+
+ponder.on("BleuStakingContract:Unstaked", async ({ event, context }) => {
+  await context.db.insert(bleuNFTStaking).values({
+    user: event.args.user,
+    tokenId: event.args.tokenId,
+    type: "UNSTAKED",
+    timestamp: event.args.timestamp,
+  });
+});

--- a/apps/indexer/utils/getContractAddress.ts
+++ b/apps/indexer/utils/getContractAddress.ts
@@ -1,0 +1,13 @@
+import { getAddress } from "viem";
+import BleuDeploy from "../../contracts/broadcast/BleuNFT.s.sol/31337/run-latest.json";
+
+export function getContractAddress(name: string) {
+  const transaction = BleuDeploy.transactions.find(
+    ({ transactionType, contractName }) =>
+      transactionType === "CREATE" && contractName === name
+  );
+  if (!transaction) {
+    throw `${name} was not created`;
+  }
+  return getAddress(transaction.contractAddress);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       ponder:
         specifier: ^0.9.5
         version: 0.9.5(@opentelemetry/api@1.9.0)(@types/node@22.13.1)(@types/react@19.0.8)(bufferutil@4.0.9)(hono@4.7.0)(lightningcss@1.29.1)(typescript@5.7.3)(utf-8-validate@5.0.10)(viem@2.22.22(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10))
+      uuid:
+        specifier: ^11.1.0
+        version: 11.1.0
       viem:
         specifier: ^2.21.3
         version: 2.22.22(bufferutil@4.0.9)(typescript@5.7.3)(utf-8-validate@5.0.10)
@@ -3070,6 +3073,10 @@ packages:
 
   util@0.12.5:
     resolution: {integrity: sha512-kZf/K6hEIrWHI6XqOFUiiMa+79wE/D8Q+NCNAWclkyg3b4d2k7s0QGepNjiABc+aR3N1PAyHL7p6UcLY6LmrnA==}
+
+  uuid@11.1.0:
+    resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
+    hasBin: true
 
   uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
@@ -6535,6 +6542,8 @@ snapshots:
       is-generator-function: 1.1.0
       is-typed-array: 1.1.15
       which-typed-array: 1.1.18
+
+  uuid@11.1.0: {}
 
   uuid@8.3.2: {}
 


### PR DESCRIPTION
This PR correctly configures the ponder indexer, updating the config file and creating the contract ABIs, the schema and the event listeners.

To properly integrate ponder with foundry, the contract addresses are dinamically fetched from the deploy script latest runs, as per [this source](https://ponder.sh/docs/advanced/foundry). This guarantess that the address will always work, even if it changes in a new anvil deploy.

Minted NFTs are stored in the database with id and owner address, and staking/unstaking events are stored in the same table, with user address, tokenId, timestamp and the type of event it represents.